### PR TITLE
macOS fixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,7 +73,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     env:
-      GOLANGCI_LINT_VERSION: '1.34.1'
+      GOLANGCI_LINT_VERSION: '1.42.1'
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - dupl
     - gocyclo
     - gofmt
-    - golint
+    - revive
     - goprintffuncname
     - lll
     - misspell

--- a/examples/getlocale-gui/android.go
+++ b/examples/getlocale-gui/android.go
@@ -1,3 +1,4 @@
+//go:build android
 // +build android
 
 package main

--- a/locale_android.go
+++ b/locale_android.go
@@ -1,3 +1,4 @@
+//go:build android
 // +build android
 
 package locale

--- a/locale_darwin.go
+++ b/locale_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin && !ios
 // +build darwin,!ios
 
 package locale
@@ -43,7 +44,7 @@ func GetLocale() (string, error) {
 		output = output[:idx]
 	}
 
-	return strings.TrimRight(strings.Replace(string(output), "_", "-", 1), "\n"), nil
+	return strings.TrimRight(strings.Replace(output, "_", "-", 1), "\n"), nil
 }
 
 // appleLanguagesRegex is used to parse the output of "defaults read -g AppleLanguages"
@@ -62,7 +63,7 @@ func GetLocales() ([]string, error) {
 		return nil, fmt.Errorf("cannot determine locale: %v (output: %s)", err, output)
 	}
 
-	matches := appleLanguagesRegex.FindAllStringSubmatch(string(output), -1)
+	matches := appleLanguagesRegex.FindAllStringSubmatch(output, -1)
 	if len(matches) == 0 {
 		return nil, fmt.Errorf("invalid output from \"defaults read -g AppleLanguages\": %s", output)
 	}

--- a/locale_ios.go
+++ b/locale_ios.go
@@ -1,3 +1,4 @@
+//go:build ios
 // +build ios
 
 package locale

--- a/locale_js.go
+++ b/locale_js.go
@@ -1,3 +1,4 @@
+//go:build js && wasm
 // +build js,wasm
 
 package locale

--- a/locale_test.go
+++ b/locale_test.go
@@ -1,3 +1,4 @@
+//go:build windows || (darwin && !ios)
 // +build windows darwin,!ios
 
 package locale

--- a/locale_unix.go
+++ b/locale_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !darwin && !js && !android
 // +build !windows,!darwin,!js,!android
 
 package locale

--- a/locale_unix_test.go
+++ b/locale_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows && !darwin && !js && !android
 // +build !windows,!darwin,!js,!android
 
 package locale

--- a/locale_windows.go
+++ b/locale_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package locale

--- a/util.go
+++ b/util.go
@@ -1,3 +1,4 @@
+//go:build !android
 // +build !android
 
 package locale

--- a/util_test.go
+++ b/util_test.go
@@ -1,3 +1,4 @@
+//go:build !android
 // +build !android
 
 package locale


### PR DESCRIPTION
Several bug fixes for macOS:

*  `defaults read -g AppleLanguages` sometimes returns values with no region information and no quote. e.g.

    ```sh
    (
        en,
        fr,
        ja
    )
    ```

* Handle the case where `defaults read -g AppleLocale` returns currency info (e.g. "en_US@currency=USD")

