### PR TITLE
Don't use app localisations if they are not supported

### DIFF
--- a/locale_darwin.m
+++ b/locale_darwin.m
@@ -2,8 +2,16 @@
 
 #import <Foundation/Foundation.h>
 
+bool hasAppTranslations() {
+    return [[[NSBundle mainBundle] localizations] count] > 1;
+}
+
 const char *preferredLocalization()
 {
+    if (!hasAppTranslations()) {
+        return "";
+    }
+
     NSString *locale = [[[NSBundle mainBundle] preferredLocalizations] firstObject];
 
     return [locale UTF8String];
@@ -11,6 +19,10 @@ const char *preferredLocalization()
 
 const char *preferredLocalizations()
 {
+    if (!hasAppTranslations()) {
+        return "";
+    }
+
     NSString *locales = [[[NSBundle mainBundle] preferredLocalizations] componentsJoinedByString:@","];
 
     return [locales UTF8String];


### PR DESCRIPTION
The fallback in that case was booted system default, not the users current preference.

So we check if the app has localisations, and if not then fallback as before.